### PR TITLE
Add travis-ci build without optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ install:
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda` 
     # install since this ensures Numpy does not get automatically upgraded.
     # - if [[ $OPTIONAL_DEPS ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
-    - if [[ $OPTIONAL_DEPS ]]; then $PIP_INSTALL healpy; fi
+    - if [[ $OPTIONAL_DEPS == true ]]; then $PIP_INSTALL healpy; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,6 @@ install:
     # conda for packages available through conda, or pip for any other
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda` 
     # install since this ensures Numpy does not get automatically upgraded.
-    # - if [[ $OPTIONAL_DEPS ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
     - if [[ $OPTIONAL_DEPS == true ]]; then $PIP_INSTALL healpy; fi
 
     # DOCUMENTATION DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,12 +88,12 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2 scipy; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy scipy; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
+        - OPTIONAL_DEPS=false
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -25,14 +26,14 @@ matrix:
         # development version of Astropy, which fixes some issues with
         # coverage testing in affiliated packages.
         - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
+          env: ASTROPY_VERSION=development SETUP_CMD='test --coverage' OPTIONAL_DEPS=true
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
+          env: SETUP_CMD='build_sphinx -w' OPTIONAL_DEPS=true
 
-        # Try Astropy development version
+        # Try Astropy development version and disable optional deps
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
         - python: 3.3
@@ -40,21 +41,21 @@ matrix:
 
         # Try all python versions with the latest numpy
         - python: 2.6
-          env: SETUP_CMD='test'
+          env: SETUP_CMD='test' OPTIONAL_DEPS=true
         - python: 2.7
-          env: SETUP_CMD='test'
+          env: SETUP_CMD='test' OPTIONAL_DEPS=true
         - python: 3.3
-          env: SETUP_CMD='test'
+          env: SETUP_CMD='test' OPTIONAL_DEPS=true
         - python: 3.4
-          env: SETUP_CMD='test'
+          env: SETUP_CMD='test' OPTIONAL_DEPS=true
 
         # Try older numpy versions
         - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.8 SETUP_CMD='test' OPTIONAL_DEPS=true
         - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.7 SETUP_CMD='test' OPTIONAL_DEPS=true
         - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.6 SETUP_CMD='test' OPTIONAL_DEPS=true
 
 before_install:
 
@@ -92,21 +93,21 @@ install:
 
     # ASTROPY
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy nose pyqt matplotlib; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy scipy; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use
     # conda for packages available through conda, or pip for any other
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda` 
     # install since this ensures Numpy does not get automatically upgraded.
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION scipy ; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL healpy wcsaxes; fi
+    # - if [[ $OPTIONAL_DEPS ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
+    - if [[ $OPTIONAL_DEPS ]]; then $PIP_INSTALL healpy; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx=1.2 matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx=1.2 pyqt matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,9 +20,9 @@ This package has the following hard dependencies:
 
 * `Astropy <http://www.astropy.org/>`__ 1.0 or later
 
-and the following optional dependencies:
+* `Scipy <http://www.scipy.org/>`__
 
-* `Scipy <http://www.scipy.org/>`__ for interpolation
+and the following optional dependencies:
 
 * `healpy <http://healpy.readthedocs.org>`_ for HEALPIX image reprojection
 


### PR DESCRIPTION
@astrofrog I saw that you used `@pytest.mark.importorskip('healpy')` here
https://github.com/astrofrog/reproject/blob/dd3086eab4802749d8cd70a55ca920d70a6e0d77/reproject/healpix/tests/test_healpix.py#L40
and wanted to use this in Gammapy, but it doesn't work:
https://travis-ci.org/gammapy/gammapy/jobs/61290205#L907
https://github.com/gammapy/gammapy/pull/258

This also doesn't work for me locally ... is this the correct way to use this mark?

Maybe the `reproject` tests on travis-ci don't fail just because there's no build where healpy is not available:
https://github.com/astrofrog/reproject/blob/master/.travis.yml#L96
I guess that should be added.