### PR TITLE
Significant improvements to performance for interpolation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 - Allow users to pass a ``field=`` option to ``reproject_from_healpix``
   to access different fields in a HEALPIX file. [#86]
 
+- Significant improvements to performance when the input data is a large
+  memory-mapped array. [#105]
+
 0.2 (2015-10-29)
 ----------------
 


### PR DESCRIPTION
When dealing with large input images, we now make sure that we never force the whole image to be read (when memory-mapped) if only a small region is needed.

@pllim - this should fix the memory issues you were seeing. Can you install reproject from my branch to check if it works correctly, and once we've confirmed this I can go ahead and merge (if tests pass)