### PR TITLE
remove mention of mode from reproject_interp docstring

### DIFF
--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -47,8 +47,8 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
         If ``input_data`` is a FITS file or an `~astropy.io.fits.HDUList`
         instance, specifies the HDU to use.
     order : int or str, optional
-        The order of the interpolation (if ``mode`` is set to
-        ``'interpolation'``). This can be either one of the following strings:
+        The order of the interpolation. This can be any of the 
+        following strings:
 
             * 'nearest-neighbor'
             * 'bilinear'


### PR DESCRIPTION
It looks to me like ``mode`` is from an earlier version, but there is no ``mode`` argument now.