### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ About
 
 The 'reproject' package is a Python package to reproject astronomical images using various techniques via a uniform interface. By *reprojection*, we mean the re-gridding of images from one world coordinate system to another (for example changing the pixel resolution, orientation, coordinate system). Currently, we have implemented reprojection of celestial images by interpolation (like [SWARP](http://www.astromatic.net/software/swarp)), as well as by finding the exact overlap between pixels on the celestial sphere (like [Montage](http://montage.ipac.caltech.edu/index.html)). It can also reproject to/from HEALPIX projections by relying on the [healpy](https://github.com/healpy/healpy) package. 
 
-For more information, including on how to install the package, see http://reproject.readthedocs.io
+For more information, including on how to install the package, see https://reproject.readthedocs.io
 
 ![screenshot](docs/images/index-4.png)
 

--- a/docs/healpix.rst
+++ b/docs/healpix.rst
@@ -11,7 +11,7 @@ Images can also be stored using the HEALPIX representation, and the
 :func:`~reproject.reproject_from_healpix` and
 :func:`~reproject.reproject_to_healpix`, which can be used to reproject
 from/to HEALPIX representations (these functions are wrappers around
-functionality provided by the `healpy <http://healpy.readthedocs.io>`_
+functionality provided by the `healpy <https://healpy.readthedocs.io>`_
 package). These functions do the reprojection using interpolation (and the
 order can be specified using the ``order`` argument). The functions can be
 imported with::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ This package has the following hard dependencies:
 
 and the following optional dependencies:
 
-* `healpy <http://healpy.readthedocs.io>`_ 1.8 or later for HEALPIX image reprojection
+* `healpy <https://healpy.readthedocs.io>`_ 1.8 or later for HEALPIX image reprojection
 
 Installation
 ============

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ long_description =
 author = Thomas Robitaille, Christoph Deil, Adam Ginsburg
 author_email = thomas.robitaille@gmail.com
 license = BSD
-url = http://reproject.readthedocs.io
+url = https://reproject.readthedocs.io
 edit_on_github = False
 github_project = astrofrog/reproject
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.