### PR TITLE
New function for determining optimal WCS/shape for set of images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='healpy'
-        - CONDA_DEPENDENCIES='Cython scipy matplotlib shapely'
+        - CONDA_CHANNELS='conda-forge'
+        - CONDA_DEPENDENCIES='Cython scipy matplotlib shapely>=1.6 healpy'
         - SETUP_XVFB=True
 
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='healpy'
-        - CONDA_DEPENDENCIES='Cython scipy matplotlib'
+        - CONDA_DEPENDENCIES='Cython scipy matplotlib shapely'
         - SETUP_XVFB=True
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
       TEST_CMD: "test"
-      CONDA_DEPENDENCIES: "cython scipy pandas"
+      CONDA_DEPENDENCIES: "cython scipy pandas shapely"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ environment:
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
       TEST_CMD: "test"
-      CONDA_DEPENDENCIES: "cython scipy pandas shapely"
+      CONDA_CHANNELS: "conda-forge"
+      CONDA_DEPENDENCIES: "cython scipy pandas shapely>=1.6"
 
   matrix:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,12 +26,14 @@ and the following optional dependencies:
 
 * `healpy <https://healpy.readthedocs.io>`_ 1.8 or later for HEALPIX image reprojection
 
+* `shapely <https://toblerity.org/shapely/project.html>`_ 1.6 or later for some of the mosaicking functionality
+
 If you build the package from the source, the following additional packages
 are required:
 
 * `Cython <http://cython.org>`__
 
-and to run the tests:
+and to run the tests, you will also need:
 
 * `Matplotlib <http://matplotlib.org/>`__
 
@@ -163,4 +165,3 @@ Reference/API
 
 .. automodapi:: reproject
    :no-inheritance-diagram:
-

--- a/reproject/compat.py
+++ b/reproject/compat.py
@@ -1,0 +1,134 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Functions backported from other modules for compatibility
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from astropy.wcs import WCS
+from astropy.coordinates import BaseRADecFrame, FK4, FK4NoETerms, FK5, ICRS, Galactic
+
+try:
+
+    from astropy.wcs.utils import celestial_frame_to_wcs, custom_frame_to_wcs_mappings
+
+except ImportError:  # Astropy < 3.0
+
+    def _celestial_frame_to_wcs_builtin(frame, projection='TAN'):
+
+        # Create a 2-dimensional WCS
+        wcs = WCS(naxis=2)
+
+        if isinstance(frame, BaseRADecFrame):
+
+            xcoord = 'RA--'
+            ycoord = 'DEC-'
+            if isinstance(frame, ICRS):
+                wcs.wcs.radesys = 'ICRS'
+            elif isinstance(frame, FK4NoETerms):
+                wcs.wcs.radesys = 'FK4-NO-E'
+                wcs.wcs.equinox = frame.equinox.byear
+            elif isinstance(frame, FK4):
+                wcs.wcs.radesys = 'FK4'
+                wcs.wcs.equinox = frame.equinox.byear
+            elif isinstance(frame, FK5):
+                wcs.wcs.radesys = 'FK5'
+                wcs.wcs.equinox = frame.equinox.jyear
+            else:
+                return None
+        elif isinstance(frame, Galactic):
+            xcoord = 'GLON'
+            ycoord = 'GLAT'
+        else:
+            return None
+
+        wcs.wcs.ctype[0] = xcoord + '-' + projection
+        wcs.wcs.ctype[1] = ycoord + '-' + projection
+
+        # Make sure that e.g. LONPOLE and other parameters are set
+        # wcs.wcs.set()
+
+        return wcs
+
+    FRAME_WCS_MAPPINGS = [[_celestial_frame_to_wcs_builtin]]
+
+    class custom_frame_to_wcs_mappings(object):
+        def __init__(self, mappings=[]):
+            if hasattr(mappings, '__call__'):
+                mappings = [mappings]
+            FRAME_WCS_MAPPINGS.append(mappings)
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, type, value, tb):
+            FRAME_WCS_MAPPINGS.pop()
+
+    def celestial_frame_to_wcs(frame, projection='TAN'):
+        """
+        For a given coordinate frame, return the corresponding WCS object.
+
+        Note that the returned WCS object has only the elements corresponding to
+        coordinate frames set (e.g. ctype, equinox, radesys).
+
+        Parameters
+        ----------
+        frame : :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass instance
+            An instance of a :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame`
+            subclass instance for which to find the WCS
+        projection : str
+            Projection code to use in ctype, if applicable
+
+        Returns
+        -------
+        wcs : :class:`~astropy.wcs.WCS` instance
+            The corresponding WCS object
+
+        Examples
+        --------
+
+        ::
+
+            >>> from astropy.wcs.utils import celestial_frame_to_wcs
+            >>> from astropy.coordinates import FK5
+            >>> frame = FK5(equinox='J2010')
+            >>> wcs = celestial_frame_to_wcs(frame)
+            >>> wcs.to_header()
+            WCSAXES =                    2 / Number of coordinate axes
+            CRPIX1  =                  0.0 / Pixel coordinate of reference point
+            CRPIX2  =                  0.0 / Pixel coordinate of reference point
+            CDELT1  =                  1.0 / [deg] Coordinate increment at reference point
+            CDELT2  =                  1.0 / [deg] Coordinate increment at reference point
+            CUNIT1  = 'deg'                / Units of coordinate increment and value
+            CUNIT2  = 'deg'                / Units of coordinate increment and value
+            CTYPE1  = 'RA---TAN'           / Right ascension, gnomonic projection
+            CTYPE2  = 'DEC--TAN'           / Declination, gnomonic projection
+            CRVAL1  =                  0.0 / [deg] Coordinate value at reference point
+            CRVAL2  =                  0.0 / [deg] Coordinate value at reference point
+            LONPOLE =                180.0 / [deg] Native longitude of celestial pole
+            LATPOLE =                  0.0 / [deg] Native latitude of celestial pole
+            RADESYS = 'FK5'                / Equatorial coordinate system
+            EQUINOX =               2010.0 / [yr] Equinox of equatorial coordinates
+
+
+        Notes
+        -----
+
+        To extend this function to frames not defined in astropy.coordinates, you
+        can write your own function which should take a
+        :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass
+        instance and a projection (given as a string) and should return either a WCS
+        instance, or `None` if the WCS could not be determined. You can register
+        this function temporarily with::
+
+            >>> from astropy.wcs.utils import celestial_frame_to_wcs, custom_frame_to_wcs_mappings
+            >>> with custom_frame_to_wcs_mappings(my_function):
+            ...     celestial_frame_to_wcs(...)
+
+        """
+        for mapping_set in FRAME_WCS_MAPPINGS:
+            for func in mapping_set:
+                wcs = func(frame, projection=projection)
+                if wcs is not None:
+                    return wcs
+        raise ValueError("Could not determine WCS corresponding to the specified "
+                         "coordinate frame.")

--- a/reproject/compat.py
+++ b/reproject/compat.py
@@ -7,6 +7,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy.wcs import WCS
 from astropy.coordinates import BaseRADecFrame, FK4, FK4NoETerms, FK5, ICRS, Galactic
 
+__doctest_skip__ = ['celestial_frame_to_wcs']
+
+__all__ = ['celestial_frame_to_wcs']
+
 try:
 
     from astropy.wcs.utils import celestial_frame_to_wcs, custom_frame_to_wcs_mappings

--- a/reproject/compat.py
+++ b/reproject/compat.py
@@ -45,11 +45,7 @@ except ImportError:  # Astropy < 3.0
         else:
             return None
 
-        wcs.wcs.ctype[0] = xcoord + '-' + projection
-        wcs.wcs.ctype[1] = ycoord + '-' + projection
-
-        # Make sure that e.g. LONPOLE and other parameters are set
-        # wcs.wcs.set()
+        wcs.wcs.ctype = xcoord + '-' + projection, ycoord + '-' + projection
 
         return wcs
 

--- a/reproject/mosaicking.py
+++ b/reproject/mosaicking.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord, ICRS
 from astropy.wcs.utils import (pixel_to_skycoord, skycoord_to_pixel,
-                               celestial_frame_to_wcs, proj_plane_pixel_scales)
+                               proj_plane_pixel_scales)
 
+from .compat import celestial_frame_to_wcs
 from .utils import parse_input_data
 
 __all__ = ['find_optimal_celestial_wcs']
@@ -41,7 +41,8 @@ def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
     frame : `~astropy.coordinates.BaseCoordinateFrame`
         The coordinate system for the final image (defaults to ICRS)
     auto_rotate : bool
-        Whether to rotate the header to minimize the final image area
+        Whether to rotate the header to minimize the final image area (if
+        `True`, requires shapely to be installed)
     projection : str
         Three-letter code for the WCS projection
     resolution : `~astropy.units.Quantity`

--- a/reproject/mosaicking.py
+++ b/reproject/mosaicking.py
@@ -168,9 +168,9 @@ def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
 
         # Determine the smallest angle that would cause the rectangle to be
         # lined up with the axes.
-        angle = angle % 90
-        if angle > 45:
-            angle -= 90
+        angle = angle % (np.pi / 2)
+        if angle > np.pi / 4:
+            angle -= np.pi / 2
 
         # Set rotation matrix (use PC instead of CROTA2 since PC is the
         # recommended approach)

--- a/reproject/mosaicking.py
+++ b/reproject/mosaicking.py
@@ -72,13 +72,13 @@ def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
     for array, wcs in input_data:
 
         if array.ndim != 2:
-            raise ValueError("input data is not 2-dimensional")
+            raise ValueError("Input data is not 2-dimensional")
 
         if wcs.naxis != 2:
-            raise ValueError("input WCS is not 2-dimensional")
+            raise ValueError("Input WCS is not 2-dimensional")
 
         if not wcs.has_celestial:
-            raise TypeError("WCS does not have celestial component")
+            raise TypeError("WCS does not have celestial components")
 
         # Find pixel coordinates of corners. In future if we are worried about
         # significant distortions of the edges in the reprojection process we

--- a/reproject/mosaicking.py
+++ b/reproject/mosaicking.py
@@ -1,0 +1,191 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord, ICRS
+from astropy.wcs.utils import (pixel_to_skycoord, skycoord_to_pixel,
+                               celestial_frame_to_wcs, proj_plane_pixel_scales)
+
+from .utils import parse_input_data
+
+__all__ = ['find_optimal_celestial_wcs']
+
+
+def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
+                               projection='TAN', resolution=None,
+                               reference=None):
+    """
+    Given one or more images, return an optimal WCS projection object and shape.
+
+    This currently only works with 2-d images with celestial WCS.
+
+    Parameters
+    ----------
+    input_data : iterable
+        One or more input datasets to include in the calculation of the final WCS.
+        This should be an iterable containing one entry for each dataset, where
+        a single dataset is one of:
+
+            * The name of a FITS file
+            * An `~astropy.io.fits.HDUList` object
+            * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
+              `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
+              instance
+            * A tuple where the first element is a `~numpy.ndarray` and the
+              second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
+
+    frame : `~astropy.coordinates.BaseCoordinateFrame`
+        The coordinate system for the final image (defaults to ICRS)
+    auto_rotate : bool
+        Whether to rotate the header to minimize the final image area
+    projection : str
+        Three-letter code for the WCS projection
+    resolution : `~astropy.units.Quantity`
+        The resolution of the final image. If not specified, this is the
+        smallest resolution of the input images.
+    reference : `~astropy.coordinates.SkyCoord`
+        The reference coordinate for the final header. If not specified, this
+        is determined automatically from the input images.
+    """
+
+    # TODO: support higher-dimensional datasets in future
+    # TODO: take into account NaN values when determining the extent of the final WCS
+
+    if frame is None:
+        frame = ICRS()
+
+    input_data = [parse_input_data(data) for data in input_data]
+
+    # We start off by looping over images, checking that they are indeed
+    # celestial images, and building up a list of all corners and all reference
+    # coordinates in celestial (ICRS) coordinates.
+
+    corners = []
+    references = []
+    resolutions = []
+
+    for array, wcs in input_data:
+
+        if array.ndim != 2:
+            raise ValueError("input data is not 2-dimensional")
+
+        if wcs.naxis != 2:
+            raise ValueError("input WCS is not 2-dimensional")
+
+        if not wcs.has_celestial:
+            raise TypeError("WCS does not have celestial component")
+
+        # Find pixel coordinates of corners. In future if we are worried about
+        # significant distortions of the edges in the reprojection process we
+        # could simply add arbitrary numbers of midpoints to this list.
+        ny, nx = array.shape
+        xc = np.array([-0.5, nx - 0.5, nx - 0.5, -0.5])
+        yc = np.array([-0.5, -0.5, ny - 0.5, ny - 0.5])
+
+        # We have to do .frame here to make sure that we get an ICRS object
+        # without any 'hidden' attributes, otherwise the stacking below won't
+        # work. TODO: check if we need to enable distortions here.
+        corners.append(pixel_to_skycoord(xc, yc, wcs, origin=0).icrs.frame)
+
+        # We now figure out the reference coordinate for the image in ICRS. The
+        # easiest way to do this is actually to use pixel_to_skycoord with the
+        # reference position in pixel coordinates. We have to set origin=1
+        # because crpix values are 1-based.
+        xp, yp = wcs.wcs.crpix
+        references.append(pixel_to_skycoord(xp, yp, wcs, origin=1).icrs.frame)
+
+        # Find the pixel scale at the reference position - we take the minimum
+        # since we are going to set up a header with 'square' pixels with the
+        # smallest resolution specified.
+        scales = proj_plane_pixel_scales(wcs)
+        resolutions.append(np.min(np.abs(scales)))
+
+    # We now stack the coordinates - however the ICRS class can't do this
+    # so we have to use the high-level SkyCoord class.
+    corners = SkyCoord(corners)
+    references = SkyCoord(references)
+
+    # If no reference coordinate has been passed in for the final header, we
+    # determine the reference coordinate as the mean of all the reference
+    # positions. This choice is as good as any and if the user really cares,
+    # they can set  it manually.
+    if reference is None:
+        reference = SkyCoord(references.data.mean(), frame=references.frame)
+
+    # In any case, we need to convert the reference coordinate (either specified
+    # or automatically determined) to the requested final frame.
+    reference = reference.transform_to(frame)
+
+    # Determine resolution if not specified
+    if resolution is None:
+        resolution = np.min(resolutions) * u.deg
+
+    # Determine the resolution in degrees
+    cdelt = resolution.to(u.deg).value
+
+    # Construct WCS object centered on position
+    wcs_final = celestial_frame_to_wcs(frame, projection=projection)
+
+    rep = reference.represent_as('unitspherical')
+    wcs_final.wcs.crval = rep.lon.degree, rep.lat.degree
+    wcs_final.wcs.cdelt = -cdelt, cdelt
+
+    # For now, set crpix to (1, 1) and we'll then figure out where all the images
+    # fall in this projection, then we'll adjust crpix.
+    wcs_final.wcs.crpix = (1, 1)
+
+    # Find pixel coordinates of all corners in the final WCS projection. We use origin=1
+    # since we are trying to determine crpix values.
+    xp, yp = skycoord_to_pixel(corners, wcs_final, origin=1)
+
+    if auto_rotate:
+
+        # Use shapely to represent the points and find the minimum rotated rectangle
+        from shapely.geometry import MultiPoint
+        mp = MultiPoint(list(zip(xp, yp)))
+
+        # The following returns a list of rectangle vertices - in fact there are
+        # 5 coordinates because shapely represents it as a closed polygon with
+        # the same first/last vertex.
+        xr, yr = mp.minimum_rotated_rectangle.exterior.coords.xy
+
+        # Determine angle between two of the vertices. It doesn't matter which
+        # ones they are, we just want to know how far from being straight the
+        # rectangle is.
+        angle = np.arctan2(yr[1] - yr[0], xr[1] - xr[0])
+
+        # Determine the smallest angle that would cause the rectangle to be
+        # lined up with the axes.
+        angle = angle % 90
+        if angle > 45:
+            angle -= 90
+
+        # Set rotation matrix (use PC instead of CROTA2 since PC is the
+        # recommended approach)
+        pc = np.array([[np.cos(angle), -np.sin(angle)],
+                       [np.sin(angle), np.cos(angle)]])
+        wcs_final.wcs.pc = pc
+
+        # Recompute pixel coordinates (more accurate than simply rotating xp, yp)
+        xp, yp = skycoord_to_pixel(corners, wcs_final, origin=1)
+
+    # Find the full range of values
+    xmin = xp.min()
+    xmax = xp.max()
+    ymin = yp.min()
+    ymax = yp.max()
+
+    # Update crpix so that the lower range falls on the bottom and left. We add
+    # 0.5 because in the final image the bottom left corner should be at (0.5,
+    # 0.5) not (1, 1).
+    wcs_final.wcs.crpix = (1 - xmin) + 0.5, (1 - ymin) + 0.5
+
+    # Return the final image shape too
+    naxis1 = int(round(xmax - xmin))
+    naxis2 = int(round(ymax - ymin))
+
+    return wcs_final, (naxis2, naxis1)

--- a/reproject/tests/test_mosaicking.py
+++ b/reproject/tests/test_mosaicking.py
@@ -1,4 +1,10 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import absolute_import, division, print_function
+
 from copy import deepcopy
+
+import pytest
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -6,6 +12,13 @@ from numpy.testing import assert_allclose
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord, FK5, Galactic
 from astropy import units as u
+
+try:
+    import shapely  # noqa
+except ImportError:
+    SHAPELY_INSTALLED = False
+else:
+    SHAPELY_INSTALLED = True
 
 from ..mosaicking import find_optimal_celestial_wcs
 
@@ -56,6 +69,7 @@ class TestOptimalWCS():
         wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], resolution=3 * u.arcmin)
         assert_allclose(wcs.wcs.cdelt, (-0.05, 0.05))
 
+    @pytest.mark.skipif('not SHAPELY_INSTALLED')
     def test_auto_rotate(self):
 
         # To test auto_rotate, we set the frame to Galactic and the final image

--- a/reproject/tests/test_mosaicking.py
+++ b/reproject/tests/test_mosaicking.py
@@ -7,7 +7,7 @@ from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord, FK5, Galactic
 from astropy import units as u
 
-from ..wcs_utils import find_optimal_celestial_wcs
+from ..mosaicking import find_optimal_celestial_wcs
 
 
 class TestOptimalWCS():

--- a/reproject/tests/test_mosaicking.py
+++ b/reproject/tests/test_mosaicking.py
@@ -127,3 +127,29 @@ class TestOptimalWCS():
 
         wcs, shape = find_optimal_celestial_wcs(input_data)
         assert_allclose(wcs.wcs.cdelt, (-0.01, 0.01))
+
+    def test_invalid_array_shape(self):
+
+        array = np.ones((30, 20, 10))
+
+        with pytest.raises(ValueError) as exc:
+            wcs, shape = find_optimal_celestial_wcs([(array, self.wcs)])
+        assert exc.value.args[0] == 'Input data is not 2-dimensional'
+
+    def test_invalid_wcs_shape(self):
+
+        wcs = WCS(naxis=3)
+        wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'VELO-LSR'
+        wcs.wcs.set()
+
+        with pytest.raises(ValueError) as exc:
+            wcs, shape = find_optimal_celestial_wcs([(self.array, wcs)])
+        assert exc.value.args[0] == 'Input WCS is not 2-dimensional'
+
+    def test_invalid_not_celestial(self):
+
+        self.wcs.wcs.ctype = 'OFFSETX', 'OFFSETY'
+
+        with pytest.raises(TypeError) as exc:
+            wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)])
+        assert exc.value.args[0] == 'WCS does not have celestial components'

--- a/reproject/tests/test_mosaicking.py
+++ b/reproject/tests/test_mosaicking.py
@@ -88,7 +88,7 @@ class TestOptimalWCS():
         assert np.isnan(wcs.wcs.equinox)
         assert wcs.wcs.radesys == ''
 
-        assert_allclose(wcs.wcs.crpix, (31, 16))
+        assert_allclose(wcs.wcs.crpix, (10, 15))
         assert shape == (30, 40)
 
     @pytest.mark.skipif('not SHAPELY_INSTALLED')

--- a/reproject/tests/test_mosaicking.py
+++ b/reproject/tests/test_mosaicking.py
@@ -87,8 +87,8 @@ class TestOptimalWCS():
         assert np.isnan(wcs.wcs.equinox)
         assert wcs.wcs.radesys == ''
 
-        assert_allclose(wcs.wcs.crpix, (15, 31))
-        assert shape == (40, 30)
+        assert_allclose(wcs.wcs.crpix, (31, 16))
+        assert shape == (30, 40)
 
     def test_multiple_size(self):
 

--- a/reproject/tests/test_wcs_utils.py
+++ b/reproject/tests/test_wcs_utils.py
@@ -1,13 +1,16 @@
+from copy import deepcopy
+
 import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy.wcs import WCS
-from astropy.coordinates import FK5
+from astropy.coordinates import SkyCoord, FK5, Galactic
+from astropy import units as u
 
 from ..wcs_utils import find_optimal_celestial_wcs
 
 
-class TestSingleImage():
+class TestOptimalWCS():
 
     def setup_method(self, method):
 
@@ -22,11 +25,91 @@ class TestSingleImage():
 
     def test_identity(self):
 
-        wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], frame=FK5(), projection='TAN')
+        wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], frame=FK5())
+
         assert tuple(wcs.wcs.ctype) == ('RA---TAN', 'DEC--TAN')
-        assert_allclose(wcs.wcs.crpix, (10, 15))
         assert_allclose(wcs.wcs.crval, (43, 23))
         assert_allclose(wcs.wcs.cdelt, (-0.1, 0.1))
         assert wcs.wcs.equinox == 2000
         assert wcs.wcs.radesys == 'FK5'
+
+        assert_allclose(wcs.wcs.crpix, (10, 15))
         assert shape == (30, 40)
+
+    def test_frame_projection(self):
+
+        wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], frame=Galactic(),
+                                                projection='CAR')
+
+        assert tuple(wcs.wcs.ctype) == ('GLON-CAR', 'GLAT-CAR')
+        c = SkyCoord(43, 23, unit=('deg', 'deg'), frame='fk5').galactic
+        assert_allclose(wcs.wcs.crval, (c.l.degree, c.b.degree))
+        assert_allclose(wcs.wcs.cdelt, (-0.1, 0.1))
+        assert np.isnan(wcs.wcs.equinox)
+        assert wcs.wcs.radesys == ''
+
+        # The following values are empirical and just to make sure there are no regressions
+        assert_allclose(wcs.wcs.crpix, (16.21218937, 28.86119519))
+        assert shape == (47, 50)
+
+    def test_resolution(self):
+        wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], resolution=3 * u.arcmin)
+        assert_allclose(wcs.wcs.cdelt, (-0.05, 0.05))
+
+    def test_auto_rotate(self):
+
+        # To test auto_rotate, we set the frame to Galactic and the final image
+        # should have the same size as the input image. In this case, the image
+        # actually gets rotated 90 degrees, so the values aren't quite the same
+        # as the input, but they are round values.
+
+        wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)],
+                                                frame=Galactic(), auto_rotate=True)
+
+        assert tuple(wcs.wcs.ctype) == ('GLON-TAN', 'GLAT-TAN')
+        c = SkyCoord(43, 23, unit=('deg', 'deg'), frame='fk5').galactic
+        assert_allclose(wcs.wcs.crval, (c.l.degree, c.b.degree))
+        assert_allclose(wcs.wcs.cdelt, (-0.1, 0.1))
+        assert np.isnan(wcs.wcs.equinox)
+        assert wcs.wcs.radesys == ''
+
+        assert_allclose(wcs.wcs.crpix, (15, 31))
+        assert shape == (40, 30)
+
+    def test_multiple_size(self):
+
+        wcs1 = self.wcs
+
+        wcs2 = deepcopy(self.wcs)
+        wcs2.wcs.crpix[0] += 10
+
+        wcs3 = deepcopy(self.wcs)
+        wcs3.wcs.crpix[1] -= 5
+
+        input_data = [(self.array, wcs1), (self.array, wcs2), (self.array, wcs3)]
+
+        wcs, shape = find_optimal_celestial_wcs(input_data, frame=FK5())
+
+        assert tuple(wcs.wcs.ctype) == ('RA---TAN', 'DEC--TAN')
+        assert_allclose(wcs.wcs.crval, (43, 23))
+        assert_allclose(wcs.wcs.cdelt, (-0.1, 0.1))
+        assert wcs.wcs.equinox == 2000
+        assert wcs.wcs.radesys == 'FK5'
+
+        assert_allclose(wcs.wcs.crpix, (20, 15))
+        assert shape == (35, 50)
+
+    def test_multiple_resolution(self):
+
+        wcs1 = self.wcs
+
+        wcs2 = deepcopy(self.wcs)
+        wcs2.wcs.cdelt = -0.01, 0.02
+
+        wcs3 = deepcopy(self.wcs)
+        wcs3.wcs.crpix = -0.2, 0.3
+
+        input_data = [(self.array, wcs1), (self.array, wcs2), (self.array, wcs3)]
+
+        wcs, shape = find_optimal_celestial_wcs(input_data)
+        assert_allclose(wcs.wcs.cdelt, (-0.01, 0.01))

--- a/reproject/tests/test_wcs_utils.py
+++ b/reproject/tests/test_wcs_utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from astropy.wcs import WCS
+from astropy.coordinates import FK5
+
+from ..wcs_utils import find_optimal_celestial_wcs
+
+
+class TestSingleImage():
+
+    def setup_method(self, method):
+
+        self.wcs = WCS(naxis=2)
+        self.wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN'
+        self.wcs.wcs.crpix = 10, 15
+        self.wcs.wcs.crval = 43, 23
+        self.wcs.wcs.cdelt = -0.1, 0.1
+        self.wcs.wcs.equinox = 2000.
+
+        self.array = np.ones((30, 40))
+
+    def test_identity(self):
+
+        wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], frame=FK5(), projection='TAN')
+        assert tuple(wcs.wcs.ctype) == ('RA---TAN', 'DEC--TAN')
+        assert_allclose(wcs.wcs.crpix, (10, 15))
+        assert_allclose(wcs.wcs.crval, (43, 23))
+        assert_allclose(wcs.wcs.cdelt, (-0.1, 0.1))
+        assert wcs.wcs.equinox == 2000
+        assert wcs.wcs.radesys == 'FK5'
+        assert shape == (30, 40)

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -14,8 +14,11 @@ def parse_input_data(input_data, hdu_in=None):
     if isinstance(input_data, six.string_types):
         return parse_input_data(fits.open(input_data), hdu_in=hdu_in)
     elif isinstance(input_data, HDUList):
-        if len(input_data) > 1 and hdu_in is None:
-            raise ValueError("More than one HDU is present, please specify HDU to use with ``hdu_in=`` option")
+        if hdu_in is None:
+            if len(input_data) > 1:
+                raise ValueError("More than one HDU is present, please specify HDU to use with ``hdu_in=`` option")
+            else:
+                hdu_in = 0
         return parse_input_data(input_data[hdu_in])
     elif isinstance(input_data, (PrimaryHDU, ImageHDU, CompImageHDU)):
         return input_data.data, WCS(input_data.header)

--- a/reproject/wcs_utils.py
+++ b/reproject/wcs_utils.py
@@ -7,12 +7,17 @@ WCS-related utilities
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import numpy as np
 from astropy import units as u
-from astropy.coordinates import UnitSphericalRepresentation
-from astropy.wcs.utils import wcs_to_celestial_frame
+from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
+from astropy.io import fits
 from astropy.wcs import WCS
+from astropy.wcs.utils import (wcs_to_celestial_frame, pixel_to_skycoord, skycoord_to_pixel,
+                               celestial_frame_to_wcs, proj_plane_pixel_scales)
 
-__all__ = ['convert_world_coordinates']
+from .utils import parse_input_data
+
+__all__ = ['convert_world_coordinates', 'find_optimal_celestial_wcs']
 
 
 def convert_world_coordinates(lon_in, lat_in, wcs_in, wcs_out):
@@ -62,3 +67,177 @@ def convert_world_coordinates(lon_in, lat_in, wcs_in, wcs_out):
     lat_out = coords_out.represent_as('unitspherical').lat.to(lat_out_unit).value
 
     return lon_out, lat_out
+
+
+def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
+                               projection='TAN', resolution=None,
+                               reference=None):
+    """
+    Given one or more images, return an optimal WCS projection object and shape.
+
+    This currently only works with 2-d images with celestial WCS.
+
+    Parameters
+    ----------
+    input_data : iterable
+        One or more input datasets to include in the calculation of the final WCS.
+        This should be an iterable containing one entry for each dataset, where
+        a single dataset is one of:
+
+            * The name of a FITS file
+            * An `~astropy.io.fits.HDUList` object
+            * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
+              `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
+              instance
+            * A tuple where the first element is a `~numpy.ndarray` and the
+              second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
+
+    frame : `~astropy.coordinates.BaseCoordinateFrame`
+        The coordinate system for the final image (defaults to ICRS)
+    auto_rotate : bool
+        Whether to rotate the header to minimize the final image area
+    projection : str
+        Three-letter code for the WCS projection
+    resolution : `~astropy.units.Quantity`
+        The resolution of the final image. If not specified, this is the
+        smallest resolution of the input images.
+    reference : `~astropy.coordinates.SkyCoord`
+        The reference coordinate for the final header. If not specified, this
+        is determined automatically from the input images.
+    """
+
+    # TODO: support higher-dimensional datasets in future
+    # TODO: take into account NaN values when determining the extent of the final WCS
+
+    if frame is None:
+        frame = ICRS()
+
+    input_data = [parse_input_data(data) for data in input_data]
+
+    # We start off by looping over images, checking that they are indeed
+    # celestial images, and building up a list of all corners and all reference
+    # coordinates in celestial (ICRS) coordinates.
+
+    corners = []
+    references = []
+    resolutions = []
+
+    for array, wcs in input_data:
+
+        if array.ndim != 2:
+            raise ValueError("input data is not 2-dimensional")
+
+        if wcs.naxis != 2:
+            raise ValueError("input WCS is not 2-dimensional")
+
+        if not wcs.has_celestial:
+            raise TypeError("WCS does not have celestial component")
+
+        # Find pixel coordinates of corners. In future if we are worried about
+        # significant distortions of the edges in the reprojection process we
+        # could simply add arbitrary numbers of midpoints to this list.
+        ny, nx = array.shape
+        xc = np.array([-0.5, nx - 0.5, nx - 0.5, -0.5])
+        yc = np.array([-0.5, -0.5, ny - 0.5, ny - 0.5])
+
+        # We have to do .frame here to make sure that we get an ICRS object
+        # without any 'hidden' attributes, otherwise the stacking below won't
+        # work. TODO: check if we need to enable distortions here.
+        corners.append(pixel_to_skycoord(xc, yc, wcs).icrs.frame)
+
+        # We now figure out the reference coordinate for the image in ICRS. The
+        # easiest way to do this is actually to use pixel_to_skycoord with the
+        # reference position in pixel coordinates.
+        xp, yp = wcs.wcs.crpix
+        references.append(pixel_to_skycoord(xp, yp, wcs).icrs.frame)
+
+        # Find the pixel scale at the reference position - we take the minimum
+        # since we are going to set up a header with 'square' pixels with the
+        # smallest resolution specified.
+        scales = proj_plane_pixel_scales(wcs)
+        resolutions.append(np.min(np.abs(scales)))
+
+    # We now stack the coordinates - however the ICRS class can't do this
+    # so we have to use the high-level SkyCoord class.
+    corners = SkyCoord(corners)
+    references = SkyCoord(references)
+
+    # If no reference coordinate has been passed in for the final header, we
+    # determine the reference coordinate as the mean of all the reference
+    # positions. This choice is as good as any and if the user really cares,
+    # they can set  it manually.
+    if reference is None:
+        reference = SkyCoord(references.data.mean(), frame=references.frame)
+
+    # In any case, we need to convert the reference coordinate (either specified
+    # or automatically determined) to the requested final frame.
+    reference = reference.transform_to(frame)
+
+    # Determine resolution if not specified
+    if resolution is None:
+        resolution = np.min(resolutions) * u.deg
+
+    # Determine the resolution in degrees
+    cdelt = resolution.to(u.deg).value
+
+    # Construct WCS object centered on position
+    wcs_final = celestial_frame_to_wcs(frame, projection=projection)
+    wcs_final.wcs.crval = reference.spherical.lon.degree, reference.spherical.lat.degree
+    wcs_final.wcs.cdelt = -cdelt, cdelt
+
+    # For now, set crpix to 0 and we'll then figure out where all the images
+    # fall in this projection, then we'll adjust crpix.
+    wcs_final.wcs.crpix = 0, 0
+
+    # Find pixel coordinates of all corners in the final WCS projection
+    xp, yp = skycoord_to_pixel(corners, wcs_final)
+
+    if auto_rotate:
+
+        # Use shapely to represent the points and find the minimum rotated rectangle
+        from shapely.geometry import MultiPoint
+        mp = MultiPoint(list(zip(xp, yp)))
+
+        # The following returns a list of rectangle vertices - in fact there are
+        # 5 coordinates because shapely represents it as a closed polygon with
+        # the same first/last vertex.
+        xr, yr = mp.minimum_rotated_rectangle.exterior.coords.xy
+
+        # Determine angle between two of the vertices. It doesn't matter which
+        # ones they are, we just want to know how far from being straight the
+        # rectangle is.
+        angle = np.arctan2(yr[1] - yr[0], xr[1] - xr[0])
+
+        # Determine the smallest angle that would cause the rectangle to be
+        # lined up with the axes.
+        angle = angle % 90
+        if angle > 45:
+            angle -= 90
+
+        # Rotate the original corner coordinates by this angle and then find
+        # the range of coordinates. We do the following in one go so we can
+        # overwrite xp and yp in one go.
+        xp, yp = (xp * np.cos(-angle) - yp * np.sin(-angle),
+                  xp * np.sin(-angle) + yp * np.cos(-angle))
+
+        # Set rotation matrix (use PC instead of CROTA2 since PC is the
+        # recommended approach)
+        pc = np.array([[np.cos(angle), -np.sin(angle)],
+                       [np.sin(angle), np.cos(angle)]])
+        wcs_final.wcs.pc = pc
+
+    # Find the full range of values
+    xmin = xp.min()
+    xmax = xp.max()
+    ymin = yp.min()
+    ymax = yp.max()
+
+    # Update crpix so that the lower range falls on the bottom and left
+    wcs_final.wcs.crpix = -xmin, -ymin
+
+    # Return the final image shape too
+    naxis1 = int(round(xmax - xmin)) + 1
+    naxis2 = int(round(ymax - ymin)) + 1
+
+    return wcs_final, (naxis2, naxis1)

--- a/reproject/wcs_utils.py
+++ b/reproject/wcs_utils.py
@@ -7,16 +7,13 @@ WCS-related utilities
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import numpy as np
 from astropy import units as u
-from astropy.coordinates import SkyCoord, ICRS, UnitSphericalRepresentation
+from astropy.coordinates import UnitSphericalRepresentation
 from astropy.wcs import WCS
-from astropy.wcs.utils import (wcs_to_celestial_frame, pixel_to_skycoord, skycoord_to_pixel,
-                               celestial_frame_to_wcs, proj_plane_pixel_scales)
+from astropy.wcs.utils import wcs_to_celestial_frame
 
-from .utils import parse_input_data
 
-__all__ = ['convert_world_coordinates', 'find_optimal_celestial_wcs']
+__all__ = ['convert_world_coordinates']
 
 
 def convert_world_coordinates(lon_in, lat_in, wcs_in, wcs_out):
@@ -62,183 +59,9 @@ def convert_world_coordinates(lon_in, lat_in, wcs_in, wcs_out):
     coords_in = frame_in.realize_frame(data)
     coords_out = coords_in.transform_to(frame_out)
 
-    lon_out = coords_out.represent_as('unitspherical').lon.to(lon_out_unit).value
-    lat_out = coords_out.represent_as('unitspherical').lat.to(lat_out_unit).value
+    rep = coords_out.represent_as('unitspherical')
+
+    lon_out = rep.lon.to(lon_out_unit).value
+    lat_out = rep.lat.to(lat_out_unit).value
 
     return lon_out, lat_out
-
-
-def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
-                               projection='TAN', resolution=None,
-                               reference=None):
-    """
-    Given one or more images, return an optimal WCS projection object and shape.
-
-    This currently only works with 2-d images with celestial WCS.
-
-    Parameters
-    ----------
-    input_data : iterable
-        One or more input datasets to include in the calculation of the final WCS.
-        This should be an iterable containing one entry for each dataset, where
-        a single dataset is one of:
-
-            * The name of a FITS file
-            * An `~astropy.io.fits.HDUList` object
-            * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
-              `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
-              instance
-            * A tuple where the first element is a `~numpy.ndarray` and the
-              second element is either a `~astropy.wcs.WCS` or a
-              `~astropy.io.fits.Header` object
-
-    frame : `~astropy.coordinates.BaseCoordinateFrame`
-        The coordinate system for the final image (defaults to ICRS)
-    auto_rotate : bool
-        Whether to rotate the header to minimize the final image area
-    projection : str
-        Three-letter code for the WCS projection
-    resolution : `~astropy.units.Quantity`
-        The resolution of the final image. If not specified, this is the
-        smallest resolution of the input images.
-    reference : `~astropy.coordinates.SkyCoord`
-        The reference coordinate for the final header. If not specified, this
-        is determined automatically from the input images.
-    """
-
-    # TODO: support higher-dimensional datasets in future
-    # TODO: take into account NaN values when determining the extent of the final WCS
-
-    if frame is None:
-        frame = ICRS()
-
-    input_data = [parse_input_data(data) for data in input_data]
-
-    # We start off by looping over images, checking that they are indeed
-    # celestial images, and building up a list of all corners and all reference
-    # coordinates in celestial (ICRS) coordinates.
-
-    corners = []
-    references = []
-    resolutions = []
-
-    for array, wcs in input_data:
-
-        if array.ndim != 2:
-            raise ValueError("input data is not 2-dimensional")
-
-        if wcs.naxis != 2:
-            raise ValueError("input WCS is not 2-dimensional")
-
-        if not wcs.has_celestial:
-            raise TypeError("WCS does not have celestial component")
-
-        # Find pixel coordinates of corners. In future if we are worried about
-        # significant distortions of the edges in the reprojection process we
-        # could simply add arbitrary numbers of midpoints to this list.
-        ny, nx = array.shape
-        xc = np.array([-0.5, nx - 0.5, nx - 0.5, -0.5])
-        yc = np.array([-0.5, -0.5, ny - 0.5, ny - 0.5])
-
-        # We have to do .frame here to make sure that we get an ICRS object
-        # without any 'hidden' attributes, otherwise the stacking below won't
-        # work. TODO: check if we need to enable distortions here.
-        corners.append(pixel_to_skycoord(xc, yc, wcs, origin=0).icrs.frame)
-
-        # We now figure out the reference coordinate for the image in ICRS. The
-        # easiest way to do this is actually to use pixel_to_skycoord with the
-        # reference position in pixel coordinates. We have to set origin=1
-        # because crpix values are 1-based.
-        xp, yp = wcs.wcs.crpix
-        references.append(pixel_to_skycoord(xp, yp, wcs, origin=1).icrs.frame)
-
-        # Find the pixel scale at the reference position - we take the minimum
-        # since we are going to set up a header with 'square' pixels with the
-        # smallest resolution specified.
-        scales = proj_plane_pixel_scales(wcs)
-        resolutions.append(np.min(np.abs(scales)))
-
-    # We now stack the coordinates - however the ICRS class can't do this
-    # so we have to use the high-level SkyCoord class.
-    corners = SkyCoord(corners)
-    references = SkyCoord(references)
-
-    # If no reference coordinate has been passed in for the final header, we
-    # determine the reference coordinate as the mean of all the reference
-    # positions. This choice is as good as any and if the user really cares,
-    # they can set  it manually.
-    if reference is None:
-        reference = SkyCoord(references.data.mean(), frame=references.frame)
-
-    # In any case, we need to convert the reference coordinate (either specified
-    # or automatically determined) to the requested final frame.
-    reference = reference.transform_to(frame)
-
-    # Determine resolution if not specified
-    if resolution is None:
-        resolution = np.min(resolutions) * u.deg
-
-    # Determine the resolution in degrees
-    cdelt = resolution.to(u.deg).value
-
-    # Construct WCS object centered on position
-    wcs_final = celestial_frame_to_wcs(frame, projection=projection)
-
-    wcs_final.wcs.crval = reference.spherical.lon.degree, reference.spherical.lat.degree
-    wcs_final.wcs.cdelt = -cdelt, cdelt
-
-    # For now, set crpix to (1, 1) and we'll then figure out where all the images
-    # fall in this projection, then we'll adjust crpix.
-    wcs_final.wcs.crpix = (1, 1)
-
-    # Find pixel coordinates of all corners in the final WCS projection. We use origin=1
-    # since we are trying to determine crpix values.
-    xp, yp = skycoord_to_pixel(corners, wcs_final, origin=1)
-
-    if auto_rotate:
-
-        # Use shapely to represent the points and find the minimum rotated rectangle
-        from shapely.geometry import MultiPoint
-        mp = MultiPoint(list(zip(xp, yp)))
-
-        # The following returns a list of rectangle vertices - in fact there are
-        # 5 coordinates because shapely represents it as a closed polygon with
-        # the same first/last vertex.
-        xr, yr = mp.minimum_rotated_rectangle.exterior.coords.xy
-
-        # Determine angle between two of the vertices. It doesn't matter which
-        # ones they are, we just want to know how far from being straight the
-        # rectangle is.
-        angle = np.arctan2(yr[1] - yr[0], xr[1] - xr[0])
-
-        # Determine the smallest angle that would cause the rectangle to be
-        # lined up with the axes.
-        angle = angle % 90
-        if angle > 45:
-            angle -= 90
-
-        # Set rotation matrix (use PC instead of CROTA2 since PC is the
-        # recommended approach)
-        pc = np.array([[np.cos(angle), -np.sin(angle)],
-                       [np.sin(angle), np.cos(angle)]])
-        wcs_final.wcs.pc = pc
-
-        # Recompute pixel coordinates (more accurate than simply rotating xp, yp)
-        xp, yp = skycoord_to_pixel(corners, wcs_final, origin=1)
-
-    # Find the full range of values
-    xmin = xp.min()
-    xmax = xp.max()
-    ymin = yp.min()
-    ymax = yp.max()
-
-    # Update crpix so that the lower range falls on the bottom and left. We add
-    # 0.5 because in the final image the bottom left corner should be at (0.5,
-    # 0.5) not (1, 1).
-    wcs_final.wcs.crpix = (1 - xmin) + 0.5, (1 - ymin) + 0.5
-
-    # Return the final image shape too
-    naxis1 = int(round(xmax - xmin))
-    naxis2 = int(round(ymax - ymin))
-
-    return wcs_final, (naxis2, naxis1)


### PR DESCRIPTION
This adds a new function for determining the optimal WCS/shape for a mosaic of images (or for a single image if changing coordinate frame). This is an alternative to the implementation of a a similar function in https://github.com/astrofrog/reproject/pull/125, but the version here takes into account different coordinate frames and can automatically rotate images if needed.

What is missing here compared to https://github.com/astrofrog/reproject/pull/125 is that we should use the minimal image excluding NaNs as input rather than the full images.