### PR TITLE
add basic FITS HIPS coadd support

### DIFF
--- a/reproject/hips/core.py
+++ b/reproject/hips/core.py
@@ -413,7 +413,7 @@ def coadd_hips(input_directories, output_directory):
                         header = fits.getheader(filepath)
                         image1 = fits.getdata(filepath)
                         image2 = fits.getdata(target_filepath)
-                        result = (image1 + image2) / 2
+                        result = np.average([image1, image2], axis=0)
                         fits.writeto(target_filepath, result, header, overwrite=True)
                     else:
                         raise NotImplementedError(f"Tile format {tile_format} not implemented")

--- a/reproject/hips/core.py
+++ b/reproject/hips/core.py
@@ -413,7 +413,7 @@ def coadd_hips(input_directories, output_directory):
                         header = fits.getheader(filepath)
                         image1 = fits.getdata(filepath)
                         image2 = fits.getdata(target_filepath)
-                        result = image1 + image2
+                        result = (image1 + image2) / 2
                         fits.writeto(target_filepath, result, header, overwrite=True)
                     else:
                         raise NotImplementedError(f"Tile format {tile_format} not implemented")

--- a/reproject/hips/core.py
+++ b/reproject/hips/core.py
@@ -409,8 +409,14 @@ def coadd_hips(input_directories, output_directory):
                         raise NotImplementedError(
                             "Convert jpg to png to allow for blending/coadding"
                         )
+                    elif tile_format == "fits":
+                        header = fits.getheader(filepath)
+                        image1 = fits.getdata(filepath)
+                        image2 = fits.getdata(target_filepath)
+                        result = image1 + image2
+                        fits.writeto(target_filepath, result, header, overwrite=True)
                     else:
-                        raise NotImplementedError()
+                        raise NotImplementedError(f"Tile format {tile_format} not implemented")
                 else:
                     shutil.copyfile(filepath, target_filepath)
 


### PR DESCRIPTION
As in the title: allow for FITS HIPS coadding.

Problem: FITS HIPS doesn't display well right now, could use help:

 * [ ] The display stretch isn't configurable and the default is saturated (at least in one specific case I've tried)
 * [ ] The background (blank area) on the sky is black instead of being empty/transparent


<img width="1701" alt="image" src="https://github.com/user-attachments/assets/a73955ba-1e50-422a-a38d-60896114f1ef" />
<img width="1714" alt="image" src="https://github.com/user-attachments/assets/cb2bfece-b91b-4400-a701-1a608cca660b" />
